### PR TITLE
Add a utility componet to icqsol that consists of utility methods to be

### DIFF
--- a/examples/colorSurfaceField.py
+++ b/examples/colorSurfaceField.py
@@ -11,6 +11,7 @@ import re
 import sys
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 # time stamp
 tid = re.sub(r'\.', '', str(time.time()))
@@ -43,14 +44,25 @@ if not os.path.exists(args.input):
     print 'ERROR: file {} does not exist'.format(args.input)
     sys.exit(2)
 
-# TODO: Enhance this to read the filoe and discover the vtk_dataset_type.
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+file_format = util.getFileFormat(args.input)
+
+if file_format != util.VTK_FORMAT:
+    print 'ERROR: file {} must be VTK format'.format(args.input)
+    sys.exit(2)
+
+vtk_dataset_type = util.getVtkDatasetType(args.input)
+
+if vtk_dataset_type not in util.VTK_DATASET_TYPES:
+    print 'ERROR: invalid VTK dataset type {}'.format(vtk_dataset_type)
+    sys.exit(2)
+
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=vtk_dataset_type)
 pDataInput = shape_mgr.loadAsVtkPolyData(args.input)
 pDataColored = shape_mgr.colorSurfaceField(pDataInput, args.colormap, field_name=args.name)
 
 if args.output:
     if args.ascii:
-        file_type = 'ascii'
+        file_type = util.ASCII
     else:
-        file_type = 'binary'
+        file_type = util.BINARY
     shape_mgr.saveVtkPolyData(vtk_poly_data=pDataColored, file_name=args.output, file_type=file_type)

--- a/examples/composeShapes.py
+++ b/examples/composeShapes.py
@@ -10,9 +10,7 @@ import sys
 import re
 
 from icqsol.shapes.icqShapeManager import ShapeManager
-
-def isVtkFile(file_name):
-    return file_name.lower().endswith('.vtk')
+from icqsol import util
 
 # time stamp
 tid = re.sub(r'\.', '', str(time.time()))
@@ -48,23 +46,24 @@ shape_mgr = ShapeManager()
 
 for shapeTuple in args.shapeTuples:
     expression_var, input_file = re.sub(r'\s*', '', shapeTuple).split(',')
-    if isVtkFile(input_file):
-        # TODO: Enhance this to read the filoe and discover the vtk_dataset_type.
-        shape_mgr.setReader(file_format='vtk', vtk_dataset_type='POLYDATA')
+    if util.isVtkFile(input_file):
+        vtk_dataset_type = util.getVtkDatasetType(input_file)
+        shape_mgr.setReader(file_format=util.VTK_FORMAT, vtk_dataset_type=vtk_dataset_type)
     else:
-        shape_mgr.setReader(file_format='ply')
+        shape_mgr.setReader(file_format=util.PLY_FORMAT)
     s = shape_mgr.loadAsShape(input_file)
     shape_tuples.append((expression_var, s))
 
-fileType = 'binary'
 if args.ascii:
-    fileType = 'ascii'
+    fileType = util.ASCII
+else:
+    fileType = util.BINARY
 
 compositeShape = shape_mgr.composeShapes(shape_tuples, args.expression)
 
 if args.output:
-    if isVtkFile(args.output):
-        shape_mgr.setWriter(file_format='vtk', vtk_dataset_type='POLYDATA')
+    if util.isVtkFile(args.output):
+        shape_mgr.setWriter(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
     else:
-        shape_mgr.setWriter(file_format='ply')
+        shape_mgr.setWriter(file_format=util.PLY_FORMAT)
     shape_mgr.saveShape(shape=compositeShape, file_name=args.output, file_type=fileType)

--- a/examples/createPrimitiveShape.py
+++ b/examples/createPrimitiveShape.py
@@ -8,6 +8,7 @@ import sys
 import re
 import numpy
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 options = {
     'sphere': {
@@ -75,21 +76,14 @@ for optNameValue in args.options:
         sys.exit(3)
     options[args.type][optName] = eval(optValue)
 
-fileFormat = 'vtk'
-fileType = 'binary'
-if args.ascii:
-    fileType = 'ascii'
-if args.output.lower().find('.ply') > 0:
-    fileFormat = 'ply'
+fileFormat =  util.getFileFormat(args.output)
 
-if fileFormat == 'vtk':
-    # TODO: Enhance this to read the filoe and discover the vtk_dataset_type.
-    shape_mgr = ShapeManager(file_format=fileFormat, vtk_dataset_type='POLYDATA')
+if fileFormat == util.VTK_FORMAT:
+    # We always produce VTK POLYDATA files.
+    shape_mgr = ShapeManager(file_format=fileFormat, vtk_dataset_type=util.POLYDATA)
 else:
     shape_mgr = ShapeManager(file_format=fileFormat)
 
-# set the surface and volume function
-surfaceFunctions = []
 evalFunction = None
 optDic = options[args.type]
 
@@ -134,4 +128,8 @@ if args.list:
         print '{:>10} --> {:>20}'.format(optName, optVal)
 
 if args.output:
-    shape_mgr.saveShape(shape=shp, file_name=args.output, file_type=fileType)
+    if args.ascii:
+        file_type = util.ASCII
+    else:
+        file_type = util.BINARY
+    shape_mgr.saveShape(shape=shp, file_name=args.output, file_type=file_type)

--- a/examples/rotateShape.py
+++ b/examples/rotateShape.py
@@ -10,6 +10,7 @@ import sys
 import re
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 # time stamp
 tid = re.sub(r'\.', '', str(time.time()))
@@ -39,17 +40,18 @@ if not args.input:
     print 'ERROR: must specify one input file with --input <file>'
     sys.exit(3)
 
-file_format = 'vtk'
-if args.output.lower().find('.ply') >= 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.input)
 
-file_type = 'binary'
 if args.ascii:
-    file_type = 'ascii'
+    file_type = util.ASCII
+else:
+    file_type = util.BINARY
 
-if file_format == 'vtk':
-    # TODO: Enhance this to read the filoe and discover the vtk_dataset_type.
-    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
+if file_format == util.VTK_FORMAT:
+    # We have a VTK file, so Get the dataset type.
+    vtk_dataset_type = util.getVtkDatasetType(args.input)
+    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type=vtk_dataset_type)
 else:
     shape_mgr = ShapeManager(file_format=file_format)
 

--- a/examples/translateShape.py
+++ b/examples/translateShape.py
@@ -10,6 +10,7 @@ import sys
 import re
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 # time stamp
 tid = re.sub(r'\.', '', str(time.time()))
@@ -39,17 +40,18 @@ if not args.input:
     print 'ERROR: must specify one input file with --input <file>'
     sys.exit(3)
 
-file_format = 'vtk'
-if args.output.lower().find('.ply') >= 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.input)
 
-file_type = 'binary'
 if args.ascii:
-    file_type = 'ascii'
+    file_type = util.ASCII
+else:
+    file_type = util.BINARY
 
-if file_format == 'vtk':
-    # TODO: Enhance this to read the filoe and discover the vtk_dataset_type.
-    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
+if file_format == util.VTK_FORMAT:
+    # We have a VTK file, so Get the dataset type.
+    vtk_dataset_type = util.getVtkDatasetType(args.input)
+    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type=vtk_dataset_type)
 else:
     shape_mgr = ShapeManager(file_format=file_format)
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='ICQSol',
       packages=['icqsol',
                 'icqsol.color', 
                 'icqsol.discretization',
-                'icqsol.shapes'],
+                'icqsol.shapes',
+                'icqsol.util'],
       requires = ['numpy', 'vtk'],
      )

--- a/tests/geometry/testBolt.py
+++ b/tests/geometry/testBolt.py
@@ -6,8 +6,9 @@ Test creation of a bolt object
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 shaft = shape_mgr.createShape('cylinder', origin=[0., 0., 0.], lengths=[1., 0., 0.], radius=0.1, n_theta=32)
 head = shape_mgr.createShape('cone', origin=[-0.06, 0., 0.], lengths=[0.14, 0., 0.], radius=0.25)
 notch1 = shape_mgr.createShape('box', origin=[-0.06, -0.015, -0.15], lengths=[0.03, 0.03, 0.30])
@@ -16,5 +17,5 @@ shape_mgr.rotateShape(notch2, axis=(1., 0., 0.), angleDeg=90.0)
 
 geom = head + shaft - notch1 - notch2
 
-shape_mgr.saveShape(shape=geom, file_name='testBolt.vtk', file_type='ascii')
+shape_mgr.saveShape(shape=geom, file_name='testBolt.vtk', file_type=util.ASCII)
 shape_mgr.show(geom, filename='testBolt.png')

--- a/tests/geometry/testCreateBox.py
+++ b/tests/geometry/testCreateBox.py
@@ -7,6 +7,7 @@ Test creation of box
 
 import argparse
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 parser = argparse.ArgumentParser(description='Create box')
 
@@ -20,20 +21,17 @@ parser.add_argument('--origin', type=str, dest='origin',
                     help='Set origin, 3 floats')
 args = parser.parse_args()
 
-file_format = 'vtk'
-if args.output.find('.ply') > 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.output)
 
-file_type = 'ascii'
-
-if file_format == 'vtk':
-    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
+if file_format == util.VTK_FORMAT:
+    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type=util.POLYDATA)
 else:
     shape_mgr = ShapeManager(file_format=file_format)
 
 s = shape_mgr.createShape('box', origin=eval(args.origin), lengths=eval(args.lengths))
 
 if args.output:
-    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=file_type)
+    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=util.ASCII)
 else:
     shape_mgr.show(s)

--- a/tests/geometry/testCreateCone.py
+++ b/tests/geometry/testCreateCone.py
@@ -7,6 +7,7 @@ Test creation of cone
 
 import argparse
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 parser = argparse.ArgumentParser(description='Create cone')
 
@@ -23,14 +24,11 @@ parser.add_argument('--n_theta', type=int, dest='n_theta', default=8,
                     help='Set number of poloidal cells')
 args = parser.parse_args()
 
-file_format = 'vtk'
-if args.output.find('.ply') > 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.output)
 
-file_type = 'ascii'
-
-if file_format == 'vtk':
-    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
+if file_format == util.VTK_FORMAT:
+    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type=util.POLYDATA)
 else:
     shape_mgr = ShapeManager(file_format=file_format)
 
@@ -41,6 +39,6 @@ s = shape_mgr.createShape('cone',
                           n_theta=args.n_theta)
 
 if args.output:
-    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=file_type)
+    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=util.ASCII)
 else:
     shape_mgr.show(s)

--- a/tests/geometry/testCreateCylinder.py
+++ b/tests/geometry/testCreateCylinder.py
@@ -7,6 +7,7 @@ Test creation of cylinders
 
 import argparse
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 parser = argparse.ArgumentParser(description='Create cylinder')
 
@@ -23,14 +24,11 @@ parser.add_argument('--n_theta', type=int, dest='n_theta', default=32,
                     help='Set number of poloidal cells')
 args = parser.parse_args()
 
-file_format = 'vtk'
-if args.output.find('.ply') > 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.output)
 
-file_type = 'ascii'
-
-if file_format == 'vtk':
-    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
+if file_format == util.VTK_FORMAT:
+    shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type=util.POLYDATA)
 else:
     shape_mgr = ShapeManager(file_format=file_format)
 
@@ -41,6 +39,6 @@ s = shape_mgr.createShape('cylinder',
                           n_theta=args.n_theta)
 
 if args.output:
-    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=file_type)
+    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=util.ASCII)
 else:
     shape_mgr.show(s)

--- a/tests/geometry/testCreateSphere.py
+++ b/tests/geometry/testCreateSphere.py
@@ -7,6 +7,7 @@ Test creation of sphere
 
 import argparse
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 parser = argparse.ArgumentParser(description='Create sphere')
 
@@ -22,13 +23,10 @@ parser.add_argument('--n_phi', type=int, dest='n_phi', default=4,
                     help='Set number of azimuthal cells')
 args = parser.parse_args()
 
-file_format = 'vtk'
-if args.output.find('.ply') > 0:
-    file_format = 'ply'
+# Get the format of the input - either vtk or ply.
+file_format = util.getFileFormat(args.output)
 
-file_type = 'ascii'
-
-if file_format == 'vtk':
+if file_format == util.VTK_FORMAT:
     shape_mgr = ShapeManager(file_format=file_format, vtk_dataset_type='POLYDATA')
 else:
     shape_mgr = ShapeManager(file_format=file_format)
@@ -40,6 +38,6 @@ s = shape_mgr.createShape('sphere',
                           n_phi=args.n_phi)
 
 if args.output:
-    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=file_type)
+    shape_mgr.saveShape(shape=s, file_name=args.output, file_type=util.ASCII)
 else:
     shape_mgr.show(s)

--- a/tests/geometry/testFromPolygons.py
+++ b/tests/geometry/testFromPolygons.py
@@ -1,11 +1,12 @@
 from icqsol.shapes.icqShapeManager import ShapeManager
 from csg.core import CSG
+from icqsol import util
 
 """
 Test construction of shape from a list of polygons
 @author pletzer@psu.edu
 """
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 cube = CSG.cube()
 # Should we test if shp == cube?
 shp = shape_mgr.shapeFromPolygons(cube)

--- a/tests/geometry/testIntersection.py
+++ b/tests/geometry/testIntersection.py
@@ -6,8 +6,9 @@ Test intersection operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('sphere', radius=1.0, origin=(0., 0., 0.))
 s2 = shape_mgr.createShape('sphere', radius=1.0, origin=(1., 0., 0.))
 geom = s1 * s2

--- a/tests/geometry/testPointInsideShape.py
+++ b/tests/geometry/testPointInsideShape.py
@@ -9,6 +9,7 @@ import numpy
 import argparse
 from icqsol.shapes.icqInside import Inside
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 parser = argparse.ArgumentParser(description='Test point inside shape')
 
@@ -16,7 +17,7 @@ parser.add_argument('--n_theta', type=int, dest='n_theta', default=8,  help='Set
 parser.add_argument('--n_phi', type=int, dest='n_phi', default=4, help='Set number of azimuthal cells')
 args = parser.parse_args()
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 shp = shape_mgr.createShape('sphere', radius=1.0, origin=(0., 0., 0.), n_theta=args.n_theta, n_phi=args.n_phi)
 
 inside = Inside(shp)

--- a/tests/geometry/testRing.py
+++ b/tests/geometry/testRing.py
@@ -6,8 +6,9 @@ Test creation of simple ring object
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 c1 = shape_mgr.createShape('cylinder', radius=0.4, origin=(0., 0., 0.), lengths=(0.5, 0., 0.))
 c2 = shape_mgr.createShape('cylinder', radius=0.2, origin=(0., 0., -0.1), lengths=(1.0, 0., 0.))
 geom = c1 - c2

--- a/tests/geometry/testSaveLoad.py
+++ b/tests/geometry/testSaveLoad.py
@@ -4,10 +4,11 @@ Test save/load methods
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 shp = shape_mgr.createShape('box', origin=[0., 0., 0.], lengths=[1., 1., 1.])
-shape_mgr.saveShape(shape=shp, file_name='testSaveLoad.vtk', file_type='ascii')
+shape_mgr.saveShape(shape=shp, file_name='testSaveLoad.vtk', file_type=util.ASCII)
 
 shp2 = shape_mgr.loadAsShape('testSaveLoad.vtk')
-shape_mgr.saveShape(shape=shp2, file_name='testSaveLoad2.vtk', file_type='ascii')
+shape_mgr.saveShape(shape=shp2, file_name='testSaveLoad2.vtk', file_type=util.ASCII)

--- a/tests/geometry/testStructuredGridRead.py
+++ b/tests/geometry/testStructuredGridRead.py
@@ -3,6 +3,7 @@
 import vtk
 import math
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 # Create structured grid and save grid in VTK file
 nLon, nLat = 16, 8
@@ -35,7 +36,5 @@ writer.SetFileTypeToASCII()
 writer.Write()
 
 # Try reading the grid
-shp_manager = ShapeManager(file_format='vtk', 
-                           vtk_dataset_type='STRUCTURED_GRID')
+shp_manager = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.STRUCTURED_GRID)
 shp = shp_manager.loadAsShape('sphereStructGrid.vtk')
-

--- a/tests/geometry/testSubtraction.py
+++ b/tests/geometry/testSubtraction.py
@@ -6,8 +6,9 @@ Test intersection operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('sphere', radius=1.0, origin=(0., 0., 0.))
 s2 = shape_mgr.createShape('sphere', radius=1.0, origin=(1., 0., 0.))
 geom = s1 - s2

--- a/tests/geometry/testSubtractionCylinders.py
+++ b/tests/geometry/testSubtractionCylinders.py
@@ -6,8 +6,9 @@ Test intersection operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('cylinder', radius=1.0, origin=(0., 0., 0.5), length=0.5)
 
 # need to make the cylinder to subtract a little longer to avoid

--- a/tests/geometry/testSurfaceInsideOtherShape.py
+++ b/tests/geometry/testSurfaceInsideOtherShape.py
@@ -4,22 +4,23 @@ Test intersection operation
 @author pletzer@psu.edu
 """
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 # box-box containment
 a = shape_mgr.createShape('box', origin=(0., 0., 0.), lengths=(1., 1., 0.2))
 b = shape_mgr.createShape('box', origin=(0.5, 0.5, 0.), lengths=(1., 1., 0.2))
 s = shape_mgr.getBoundarySurfaceInsideShape(a, b)
 
-shape_mgr.saveShape(shape=a, file_name='testInsideOtherShape_BoxBox_a.vtk', file_type='ascii')
-shape_mgr.saveShape(shape=b, file_name='testInsideOtherShape_BoxBox_b.vtk', file_type='ascii')
-shape_mgr.saveShape(shape=s, file_name='testInsideOtherShape_BoxBox_result.vtk', file_type='ascii')
+shape_mgr.saveShape(shape=a, file_name='testInsideOtherShape_BoxBox_a.vtk', file_type=util.ASCII)
+shape_mgr.saveShape(shape=b, file_name='testInsideOtherShape_BoxBox_b.vtk', file_type=util.ASCII)
+shape_mgr.saveShape(shape=s, file_name='testInsideOtherShape_BoxBox_result.vtk', file_type=util.ASCII)
 
 # box - sphere
 a = shape_mgr.createShape('box', origin=(0., 0., 0.), lengths=(1., 1., 0.2))
 b = shape_mgr.createShape('sphere', origin=(0.5, 0.5, 0.), radius=0.5)
 s = shape_mgr.getBoundarySurfaceInsideShape(a, b)
 
-shape_mgr.saveShape(shape=a, file_name='testInsideOtherShape_BoxSphere_a.vtk', file_type='ascii')
-shape_mgr.saveShape(shape=b, file_name='testInsideOtherShape_BoxSphere_b.vtk', file_type='ascii')
-shape_mgr.saveShape(shape=s, file_name='testInsideOtherShape_BoxSphere_result.vtk', file_type='ascii')
+shape_mgr.saveShape(shape=a, file_name='testInsideOtherShape_BoxSphere_a.vtk', file_type=util.ASCII)
+shape_mgr.saveShape(shape=b, file_name='testInsideOtherShape_BoxSphere_b.vtk', file_type=util.ASCII)
+shape_mgr.saveShape(shape=s, file_name='testInsideOtherShape_BoxSphere_result.vtk', file_type=util.ASCII)

--- a/tests/geometry/testToPolygons.py
+++ b/tests/geometry/testToPolygons.py
@@ -1,11 +1,12 @@
 from icqsol.shapes.icqShapeManager import ShapeManager
 from csg.core import CSG
+from icqsol import util
 
 """
 Test conversion from a shape to a list of polygons
 @author pletzer@psu.edu
 """
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 shp = shape_mgr.createShape('box', origin=[0., 0., 0.], lengths=[1., 1., 1.],)
 
 # check whether one can convert to a list of polygons

--- a/tests/geometry/testUnion.py
+++ b/tests/geometry/testUnion.py
@@ -6,8 +6,9 @@ Test union operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('sphere', radius=1.0, origin=(0., 0., 0.), n_theta=16, n_phi=8)
 s2 = shape_mgr.createShape('sphere', radius=1.0, origin=(2., 0., 0.), n_theta=16, n_phi=8)
 geom = s1 + s2

--- a/tests/geometry/testUnionCones.py
+++ b/tests/geometry/testUnionCones.py
@@ -6,8 +6,9 @@ Test union operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('cone', radius=1.0, origin=(0., 0., 0.5),
                            length=0.5, n_rho=100, n_theta=32, n_z=100)
 s2 = shape_mgr.createShape('cone', radius=0.5, origin=(0., 0., 0.),

--- a/tests/geometry/testUnionCylinders.py
+++ b/tests/geometry/testUnionCylinders.py
@@ -6,8 +6,9 @@ Test union operation
 """
 
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
-shape_mgr = ShapeManager(file_format='vtk', vtk_dataset_type='POLYDATA')
+shape_mgr = ShapeManager(file_format=util.VTK_FORMAT, vtk_dataset_type=util.POLYDATA)
 s1 = shape_mgr.createShape('cylinder', radius=1.0, origin=(0., 0., 0.5), length=0.5)
 s2 = shape_mgr.createShape('cylinder', radius=0.5, origin=(0., 0., 0.), length=1.0)
 geom = s1 + s2

--- a/tests/geometry/testUnstructuredGridRead.py
+++ b/tests/geometry/testUnstructuredGridRead.py
@@ -3,6 +3,7 @@
 import vtk
 import math
 from icqsol.shapes.icqShapeManager import ShapeManager
+from icqsol import util
 
 # Create unstructured grid and save grid in VTK file
 nLon, nLat = 16, 8
@@ -47,7 +48,5 @@ writer.SetFileTypeToASCII()
 writer.Write()
 
 # Try reading the grid
-shp_manager = ShapeManager(file_format='vtk', 
-                           vtk_dataset_type='UNSTRUCTURED_GRID')
+shp_manager = ShapeManager(file_format=util.VTK_FORMAT,  vtk_dataset_type=util.UNSTRUCTURED_GRID)
 shp = shp_manager.loadAsShape('sphereUnstructGrid.vtk')
-

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+ASCII = 'ascii'
+BINARY = 'binary'
+
+PLY_FORMAT = 'ply'
+VTK_FORMAT = 'vtk'
+
+POLYDATA = 'POLYDATA'
+STRUCTURED_GRID = 'STRUCTURED_GRID'
+UNSTRUCTURED_GRID = 'UNSTRUCTURED_GRID'
+VTK_DATASET_TYPES = [POLYDATA, STRUCTURED_GRID, UNSTRUCTURED_GRID]
+
+def getFileFormat(file_name):
+    """
+    Return a file format based on a file name extension.
+    """
+    if file_name.lower().endswith('.ply'):
+        return PLY_FORMAT
+    elif file_name.lower().endswith('.vtk'):
+        return VTK_FORMAT
+
+def getVtkDatasetType(file_name):
+    """
+    Return the VTK dataset type of a file or None if not found.
+    """
+    with open( file_name ) as fh:
+        for i, line in enumerate( fh ):
+            if i > 5:
+                # Valid VTK headers include the dataset type
+                # within the first 5 lines.
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            if 1 == 0:
+                # Line 1: vtk DataFile Version 3.0
+                if line.find( 'vtk' ) < 0:
+                    return None
+            elif line.startswith('DATASET'):
+                return line.split()[ 1 ]
+    return None
+
+def isVtkFile(file_name):
+    return file_name.lower().endswith('.vtk')


### PR DESCRIPTION
used throughout the package.  For input VTK datasets, discover the
dataset type from the file rather than hard-coding 'POLYDATA'.  Replace
references to stings like 'ascii', 'vtk', 'POLYDATA', etc throughout the
package with references to util.