### PR TITLE
Refactor the ShapeManager's addSurfaceFieldFromExpression() method to be

### DIFF
--- a/examples/addSurfaceFieldFromExpression.py
+++ b/examples/addSurfaceFieldFromExpression.py
@@ -34,7 +34,7 @@ parser.add_argument('--ascii', dest='ascii', action='store_true',
                     help='Save data in ASCII format (default is binary)')
 
 parser.add_argument('--output', dest='output',
-                    default='addSurfaceFieldFromExpression-{0}.vtk'.format(tid),
+                    default='addSurfaceFieldFromExpressionToShape-{0}.vtk'.format(tid),
                     help='VTK Output file.')
 
 args = parser.parse_args()
@@ -66,8 +66,8 @@ times = [0.0]
 if args.times:
     times = eval(args.times)
 
-pdata = shape_mgr.addSurfaceFieldFromExpression(shp, args.name,
-                                                args.expression, times)
+pdata = shape_mgr.addSurfaceFieldFromExpressionToShape(shp, args.name,
+                                                       args.expression, times)
 
 if args.output:
     # Always produce VTK POLYDATA.

--- a/examples/refineSurface.py
+++ b/examples/refineSurface.py
@@ -28,7 +28,7 @@ parser.add_argument('--ascii', dest='ascii', action='store_true',
                     help='Save data in ASCII format (default is binary)')
 
 parser.add_argument('--output', dest='output',
-                    default='addSurfaceFieldFromExpression-{0}.vtk'.format(tid),
+                    default='addSurfaceFieldFromExpressionToShape-{0}.vtk'.format(tid),
                     help='VTK Output file.')
 
 args = parser.parse_args()

--- a/shapes/icqShapeManager.py
+++ b/shapes/icqShapeManager.py
@@ -84,11 +84,11 @@ class ShapeManager(object):
             return Sphere(radius, origin, n_theta, n_phi)
         return None
 
-    def addSurfaceFieldFromExpression(self, shape, field_name, expression, time_points):
+    def addSurfaceFieldFromExpressionToVtkPolyData(self, vtk_poly_data, field_name, expression, time_points):
         """
         Add a surface field to a shape using an expression consisting of
         legal variables x,y,z (shape point coordinates) and t (time).
-        @param shape
+        @param vtk_poly_data, VTKPolyData converted from shape
         @param field_name, the name of the surface field
         @param expression, expression consisting of legal variables x, y, z, and t
         @param time_points, list of floating point values defining
@@ -99,8 +99,7 @@ class ShapeManager(object):
         # so this method returns just the data.
         valid_field_name = field_name.replace( ' ', '_' )
         # Get the points from the shape.
-        pdata = self.shapeToVTKPolyData(shape)
-        points = pdata.GetPoints()
+        points = vtk_poly_data.GetPoints()
         num_points = points.GetNumberOfPoints()
         # Define the data.
         data = vtk.vtkDoubleArray()
@@ -117,8 +116,23 @@ class ShapeManager(object):
                 t = time_points[ j ]
                 field_value = eval(expression)
                 data.SetComponent(i, j, field_value)
-        pdata.GetPointData().SetScalars(data)
-        return pdata
+        vtk_poly_data.GetPointData().SetScalars(data)
+        return vtk_poly_data
+
+    def addSurfaceFieldFromExpressionToShape(self, shape, field_name, expression, time_points):
+        """
+        Add a surface field to a shape using an expression consisting of
+        legal variables x,y,z (shape point coordinates) and t (time).
+        @param shape, shape to which to add the surface field
+        @param field_name, the name of the surface field
+        @param expression, expression consisting of legal variables x, y, z, and t
+        @param time_points, list of floating point values defining
+               snapshots in a time sequence
+        @return pdata, VTKPolyData converted from shape with added surface field
+        """
+        # Convert the shape to VTK POLYDATA.
+        vtk_poly_data = self.shapeToVTKPolyData(shape)
+        return self.addSurfaceFieldFromExpressionToVtkPolyData(vtk_poly_data, field_name, expression, time_points)
 
     def colorSurfaceField(self, vtk_poly_data, color_map,
                           field_name=None, field_component=0):


### PR DESCRIPTION
2 methods: addSurfaceFieldFromExpressionToShape() and
addSurfaceFieldFromExpressionToVtkPolyData().  This allows callers to
add surface fields to either object type.

There are 2 failing tests, but neither results from this commit.